### PR TITLE
feature/remove redundant jsx-a11y plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,9 @@
 {
   "extends": [
+    "plugin:jsx-a11y/recommended",
     "next",
     "next/core-web-vitals",
     "next/typescript",
-    "prettier",
-    "plugin:jsx-a11y/recommended"
-  ],
-  "plugins": ["jsx-a11y"]
+    "prettier"
+  ]
 }


### PR DESCRIPTION
The jsx-a11y plugin was already included in the "extends" array, making
the separate "plugins" entry redundant. This change also reorders the
extensions to group related configurations together for better readability.
